### PR TITLE
feat: implement `fromCallback` for node-style callbacks

### DIFF
--- a/.changeset/green-suns-boil.md
+++ b/.changeset/green-suns-boil.md
@@ -1,0 +1,5 @@
+---
+"windpipe": minor
+---
+
+implement `fromCallback` for stream creation

--- a/.changeset/green-suns-boil.md
+++ b/.changeset/green-suns-boil.md
@@ -2,4 +2,4 @@
 "windpipe": minor
 ---
 
-implement `fromCallback` for stream creation
+Implement `fromCallback` for stream creation

--- a/src/stream/base.ts
+++ b/src/stream/base.ts
@@ -92,6 +92,9 @@ export class StreamBase {
      * The first parameter provided to the callback (the `error`) will be emitted as an `Error`
      * atom, whilst the second parameter (the `value`) will be emitted as an `Ok` atom.
      *
+     * @example
+     * $.fromCallback((next) => someAsyncMethod(paramA, paramB, next));
+     *
      * @group Creation
      */
     static fromCallback<T, E>(cb: (next: (error: E, value: T) => unknown) => void): Stream<T, E> {

--- a/test/creation.test.ts
+++ b/test/creation.test.ts
@@ -60,4 +60,43 @@ describe.concurrent("stream creation", () => {
             expect(await s.toArray({ atoms: true })).toEqual([$.ok(1), $.ok(2), $.ok(3)]);
         });
     });
+
+    describe.concurrent("from callback", () => {
+        /**
+         * Sample function that accepts a node-style callback.
+         *
+         * @param success - Whether the method should succeed or fail.
+         * @param cb - Node-style callback to pass error or value to.
+         */
+        function someNodeCallback(
+            success: boolean,
+            cb: (error: string | undefined, value?: number) => void,
+        ) {
+            if (success) {
+                cb(undefined, 123);
+            } else {
+                cb("an error");
+            }
+        }
+
+        test("value returned from callback", async ({ expect }) => {
+            expect.assertions(1);
+
+            const s = $.fromCallback((next) => {
+                someNodeCallback(true, next);
+            });
+
+            expect(await s.toArray({ atoms: true })).toEqual([$.ok(123)]);
+        });
+
+        test("error returned from callback", async ({ expect }) => {
+            expect.assertions(1);
+
+            const s = $.fromCallback((next) => {
+                someNodeCallback(false, next);
+            });
+
+            expect(await s.toArray({ atoms: true })).toEqual([$.error("an error")]);
+        });
+    });
 });


### PR DESCRIPTION
Implement `fromCallback` stream creation method. Allows Windpipe integration with methods that take node-style callbacks.

# Example

```js
$.fromCallback((cb) => someFunction(paramA, paramB, cb));
```