### PR TITLE
fix: catch unhandled errors in `fromNext`

### DIFF
--- a/.changeset/bright-kangaroos-change.md
+++ b/.changeset/bright-kangaroos-change.md
@@ -1,0 +1,5 @@
+---
+"windpipe": patch
+---
+
+catch unhandled errors in `fromNext` stream creation

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,6 @@ export type {
 export type { MaybePromise, Truthy, CallbackOrStream } from "./util";
 
 // Export the `StreamEnd` type
-export type { StreamEnd } from "./stream";
+export { StreamEnd } from "./stream";
 
 export default Stream;

--- a/src/stream/base.ts
+++ b/src/stream/base.ts
@@ -195,12 +195,18 @@ export class StreamBase {
             new Readable({
                 objectMode: true,
                 async read() {
-                    const value = await next();
+                    try {
+                        const value = await next();
 
-                    if (value === StreamEnd) {
-                        this.push(null);
-                    } else {
-                        this.push(normalise(value));
+                        // Promise returned as normal
+                        if (value === StreamEnd) {
+                            this.push(null);
+                        } else {
+                            this.push(normalise(value));
+                        }
+                    } catch (e) {
+                        // Promise was rejected, add as an unknown error
+                        this.push(unknown(e, []));
                     }
                 },
             }),

--- a/src/stream/index.ts
+++ b/src/stream/index.ts
@@ -12,7 +12,7 @@ import {
 } from "../atom";
 import { HigherOrderStream } from "./higher-order";
 
-export type { StreamEnd } from "./base";
+export { StreamEnd } from "./base";
 
 /**
  * @template T - Type of the 'values' on the stream.


### PR DESCRIPTION
Ensure that any errors thrown within the handler passed to `fromNext` are caught and emitted as `unknown` atoms.

# Example

```js
let thrown = false;
const s = $.fromNext(() => {
    if (!thrown) {
        thrown = true;
        throw "error";
    }

    return StreamEnd;
});

await s.toArray({ atoms: true });
// Produces: [unknown("error")]
```