### PR TITLE
fix: improve exposed API

### DIFF
--- a/.changeset/pink-vans-exercise.md
+++ b/.changeset/pink-vans-exercise.md
@@ -1,0 +1,5 @@
+---
+"windpipe": patch
+---
+
+Improve exported API and generated docs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "windpipe",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "windpipe",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "ISC",
       "devDependencies": {
         "@changesets/cli": "^2.27.1",
@@ -24,6 +24,7 @@
         "typedoc": "^0.25.7",
         "typedoc-material-theme": "^1.0.2",
         "typedoc-plugin-extras": "^3.0.0",
+        "typedoc-plugin-rename-defaults": "^0.7.0",
         "typescript": "^5.3.3",
         "typescript-eslint": "^7.6.0",
         "vitest": "^1.2.0"
@@ -7331,6 +7332,30 @@
       "dev": true,
       "peerDependencies": {
         "typedoc": "0.25.x"
+      }
+    },
+    "node_modules/typedoc-plugin-rename-defaults": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-rename-defaults/-/typedoc-plugin-rename-defaults-0.7.0.tgz",
+      "integrity": "sha512-NudSQ1o/XLHNF9c4y7LzIZxfE9ltz09yCDklBPJpP5VMRvuBpYGIbQ0ZgmPz+EIV8vPx9Z/OyKwzp4HT2vDtfg==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^8.0.0"
+      },
+      "peerDependencies": {
+        "typedoc": "0.22.x || 0.23.x || 0.24.x || 0.25.x"
+      }
+    },
+    "node_modules/typedoc-plugin-rename-defaults/node_modules/camelcase": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+      "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint": "tsc && eslint .",
     "format": "eslint --fix .",
     "build": "tsup ./src/index.ts",
-    "doc": "typedoc ./src --media ./media --plugin typedoc-plugin-extras --favicon ./media/favicon.ico --footerLastModified true --plugin typedoc-material-theme --themeColor '#03284e'",
+    "doc": "typedoc ./src --media ./media --plugin typedoc-plugin-extras --favicon ./media/favicon.ico --footerLastModified true --plugin typedoc-material-theme --themeColor '#03284e' --plugin typedoc-plugin-rename-defaults",
     "test": "vitest",
     "ci:release": "npm run build && changeset publish"
   },
@@ -56,6 +56,7 @@
     "typedoc": "^0.25.7",
     "typedoc-material-theme": "^1.0.2",
     "typedoc-plugin-extras": "^3.0.0",
+    "typedoc-plugin-rename-defaults": "^0.7.0",
     "typescript": "^5.3.3",
     "typescript-eslint": "^7.6.0",
     "vitest": "^1.2.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export type {
     MaybeAtom,
 } from "./atom";
 
-// Re-export all utility types
+// Re-export useful utility types
 export type { MaybePromise, Truthy, CallbackOrStream } from "./util";
 
 // Export the `StreamEnd` type

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,19 @@
 import { Stream } from "./stream";
 
 // Export all useful types for atoms
-export type { Atom, AtomOk, AtomError, AtomUnknown } from "./atom";
+export type {
+    Atom,
+    AtomOk,
+    AtomError,
+    AtomUnknown,
+    VALUE,
+    ERROR,
+    UNKNOWN,
+    MaybeAtom,
+} from "./atom";
 
 // Re-export all utility types
-export type * from "./util";
+export type { MaybePromise, Truthy, CallbackOrStream } from "./util";
 
 // Export the `StreamEnd` type
 export type { StreamEnd } from "./stream";

--- a/src/stream/index.ts
+++ b/src/stream/index.ts
@@ -14,6 +14,10 @@ import { HigherOrderStream } from "./higher-order";
 
 export type { StreamEnd } from "./base";
 
+/**
+ * @template T - Type of the 'values' on the stream.
+ * @template E - Type of the 'errors' on the stream.
+ */
 export class Stream<T, E> extends HigherOrderStream<T, E> {
     // Re-export atom utilities for convenience
     /**


### PR DESCRIPTION
Clean up the exposed API by hiding internal utility functions. Also ensure that the generated docs label the default export as `Stream` rather than `default` for readability.