### PR TITLE
feat: Implement `.toReadable()` for streams

### DIFF
--- a/.changeset/beige-forks-clean.md
+++ b/.changeset/beige-forks-clean.md
@@ -1,0 +1,5 @@
+---
+"windpipe": minor
+---
+
+Implement `.toReadable()` method for streams

--- a/.changeset/four-donkeys-shout.md
+++ b/.changeset/four-donkeys-shout.md
@@ -1,0 +1,5 @@
+---
+"windpipe": patch
+---
+
+Fix creating streams from arrays with nullish values

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "windpipe",
-  "version": "0.7.0",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "windpipe",
-      "version": "0.7.0",
+      "version": "0.8.2",
       "license": "ISC",
       "devDependencies": {
         "@changesets/cli": "^2.27.1",

--- a/src/stream/base.ts
+++ b/src/stream/base.ts
@@ -184,7 +184,8 @@ export class StreamBase {
         array = [...array];
 
         return Stream.fromNext(async () => {
-            return array.shift() ?? StreamBase.StreamEnd;
+            if (array.length === 0) return StreamBase.StreamEnd;
+            return array.shift()!;
         });
     }
 

--- a/src/stream/consumption.ts
+++ b/src/stream/consumption.ts
@@ -148,7 +148,9 @@ export class StreamConsumption<T, E> extends StreamBase {
     toReadable(kind: "raw" | "object", options?: { atoms?: boolean }): Readable;
 
     /**
-     * Produce a readable node stream with the raw values from the stream.
+     * Produce a readable node stream with the raw values from the stream
+     * @note the stream must only contain atoms of type `string` or `Buffer`. If not, a
+     *       stream error will be emitted.
      *
      * @param options.single - Whether to emit only the first atom
      *

--- a/test/consumption.test.ts
+++ b/test/consumption.test.ts
@@ -1,8 +1,9 @@
 import { describe, test } from "vitest";
 import $ from "../src";
+import { Readable } from "node:stream";
 
 describe.concurrent("stream consumption", () => {
-    describe.concurrent("to array", () => {
+    describe.concurrent("toArray", () => {
         test("values", async ({ expect }) => {
             expect.assertions(1);
 
@@ -71,4 +72,79 @@ describe.concurrent("stream consumption", () => {
             expect(array).toEqual([]);
         });
     });
+
+    describe.concurrent("toReadable", () => {
+        test("object values", async ({ expect }) => {
+            expect.assertions(2);
+
+            const stream = $.from([1, 2, 3]).toReadable("object");
+            expect(stream).to.be.instanceof(Readable);
+
+            const values = await promisifyStream(stream);
+            expect(values).to.deep.equal([1, 2, 3]);
+        });
+
+        test("single object value", async ({ expect }) => {
+            expect.assertions(2);
+
+            const stream = $.from([1, 2, 3]).toReadable("object", { single: true });
+            expect(stream).to.be.instanceof(Readable);
+
+            const values = await promisifyStream(stream);
+            expect(values).to.deep.equal([1]);
+        });
+
+        test("object atoms", async ({ expect }) => {
+            expect.assertions(2);
+
+            const stream = $.from([$.ok(1), $.ok(2), $.error(3)]).toReadable("object", {
+                atoms: true,
+            });
+            expect(stream).to.be.instanceof(Readable);
+
+            const values = await promisifyStream(stream);
+            expect(values).to.deep.equal([$.ok(1), $.ok(2), $.error(3)]);
+        });
+
+        test("raw values", async ({ expect }) => {
+            expect.assertions(2);
+
+            const stream = $.from(["hello", " ", "world"]).toReadable("raw");
+
+            expect(stream).to.be.instanceof(Readable);
+            const values = await promisifyStream(stream);
+            expect(values.join("")).to.equal("hello world");
+        });
+
+        test("error when using object in raw stream", async ({ expect }) => {
+            expect.assertions(1);
+
+            // Creating the stream wont panic
+            const stream = $.from([1]).toReadable("raw");
+
+            // But reading it will emit an error so this should reject
+            const streamPromise = promisifyStream(stream);
+            expect(streamPromise).rejects.toBeTruthy();
+        });
+
+        test("single raw value", async ({ expect }) => {
+            expect.assertions(2);
+
+            const stream = $.from(["hello", " ", "world"]).toReadable("raw", { single: true });
+
+            expect(stream).to.be.instanceof(Readable);
+            const values = await promisifyStream(stream);
+            expect(values.join("")).to.equal("hello");
+        });
+    });
 });
+
+function promisifyStream(stream: Readable): Promise<unknown[]> {
+    const data: unknown[] = [];
+
+    return new Promise((resolve, reject) => {
+        stream.on("data", (value) => data.push(value));
+        stream.on("error", reject);
+        stream.on("end", () => resolve(data));
+    });
+}

--- a/test/consumption.test.ts
+++ b/test/consumption.test.ts
@@ -84,16 +84,6 @@ describe.concurrent("stream consumption", () => {
             expect(values).to.deep.equal([1, 2, 3]);
         });
 
-        test("single object value", async ({ expect }) => {
-            expect.assertions(2);
-
-            const stream = $.from([1, 2, 3]).toReadable("object", { single: true });
-            expect(stream).to.be.instanceof(Readable);
-
-            const values = await promisifyStream(stream);
-            expect(values).to.deep.equal([1]);
-        });
-
         test("object atoms", async ({ expect }) => {
             expect.assertions(2);
 
@@ -104,6 +94,15 @@ describe.concurrent("stream consumption", () => {
 
             const values = await promisifyStream(stream);
             expect(values).to.deep.equal([$.ok(1), $.ok(2), $.error(3)]);
+        });
+
+        test("null in object stream", async ({ expect }) => {
+            expect.assertions(2);
+
+            const stream = $.from([1, null, 2, 3]).toReadable("object");
+            expect(stream).to.be.instanceof(Readable);
+            const values = await promisifyStream(stream);
+            expect(values).to.deep.equal([1, 2, 3]);
         });
 
         test("raw values", async ({ expect }) => {
@@ -125,16 +124,6 @@ describe.concurrent("stream consumption", () => {
             // But reading it will emit an error so this should reject
             const streamPromise = promisifyStream(stream);
             expect(streamPromise).rejects.toBeTruthy();
-        });
-
-        test("single raw value", async ({ expect }) => {
-            expect.assertions(2);
-
-            const stream = $.from(["hello", " ", "world"]).toReadable("raw", { single: true });
-
-            expect(stream).to.be.instanceof(Readable);
-            const values = await promisifyStream(stream);
-            expect(values.join("")).to.equal("hello");
         });
     });
 });

--- a/test/creation.test.ts
+++ b/test/creation.test.ts
@@ -70,6 +70,18 @@ describe.concurrent("stream creation", () => {
             expect(await s.toArray({ atoms: true })).toEqual([$.ok(1), $.ok(2), $.ok(3)]);
         });
 
+        test("array with nullish values", async ({ expect }) => {
+            expect.assertions(1);
+
+            const s = $.fromArray([1, null, undefined]);
+
+            expect(await s.toArray({ atoms: true })).toEqual([
+                $.ok(1),
+                $.ok(null),
+                $.ok(undefined),
+            ]);
+        });
+
         test("don't modify original array", async ({ expect }) => {
             expect.assertions(2);
 


### PR DESCRIPTION
## Completed
- Adds `.toReadable()` to streams with options for both raw streams and objects
- Adds unit tests for `.toReadable()`

Had to do some wacky stuff with tsdoc to get it to look decent in the generated docs - might be a way to improve it potentially if you wanna give it a whirl. Not sure if there's some way to specifically mark something as an overload.