### PR TITLE
fix(transforms|batch): Allows batch operator to emit partial batches

### DIFF
--- a/src/stream/transforms.ts
+++ b/src/stream/transforms.ts
@@ -414,7 +414,7 @@ export class StreamTransforms<T, E> extends StreamConsumption<T, E> {
      * size, or can be over a period of time.
      *
      * @param options.n - Batch up to `n` items (activates batching by count)
-     * @param options.yeildRemaining - If the end of the stream is encountered and there are less
+     * @param options.yieldRemaining - If the end of the stream is encountered and there are less
      * than `n` items buffered, yield them anyway
      * @param options.timeout - Batch for `timeout` milliseconds (activates batching by timeout)
      * @param options.yieldEmpty - If `timeout` is reached and no items have been emitted on the
@@ -510,12 +510,12 @@ export class StreamTransforms<T, E> extends StreamConsumption<T, E> {
                 if (result === "timeout" && "timeout" in options) {
                     if (totalBatchSize > 0) {
                         // Work out which batches are ready
-                        const ready = Object.values(batches).filter(
-                            (batch) => batch.length >= (options?.n ?? 1),
-                        );
+                        const ready = Object.values(batches).filter((batch) => batch.length > 0);
 
                         for (const batch of ready) {
-                            const items = batch.splice(0, options?.n ?? batch.length);
+                            // If `n` in options and `n` <= batch size, use it
+                            const n = Math.min(options?.n ?? batch.length, batch.length);
+                            const items = batch.splice(0, n);
                             yield ok<T[], E>(items);
                             totalBatchSize -= items.length;
                         }


### PR DESCRIPTION
As the chief of the wind tribe, I don't mind if you have some other way you want to do this. I avoided adding another option because there's already a bunch of stuff going on in batch.

Basically I'm trying to solve the situation where:

1. Two consumers (for arguments sake) are listening for SQS events for email tracking,
2. One email (for arguments sake) is sent,
3. Each consumer receives the message 5 times, but neither reaches the `options.n` size of 10 and, thus, don't release the batch that tells AWS to delete the message,
4. The SQS queue, having sent the message 10 times, considers it dead and puts it on the DLQ.

By allowing partial batches to be emitted on a timeout, those messages can be properly cleaned up. To give you an idea of how often this happens, there's 1300 messages in the DLQ right now and I emptied it at the start of the week.