### PR TITLE
fix(windpipe): Fix `undefined` values serialising into invalid JSON

### DIFF
--- a/src/stream/consumption.ts
+++ b/src/stream/consumption.ts
@@ -86,6 +86,8 @@ export class StreamConsumption<T, E> extends StreamBase {
      * @param options.atoms - By default, only `ok` values are serialised, however enabling this
      * will serialise all values.
      *
+     * @note this will skip `undefined` values as they cannot be serialised.
+     *
      * @see {@link Stream#toReadable} if serialisation is not required
      * @group Consumption
      */
@@ -106,6 +108,11 @@ export class StreamConsumption<T, E> extends StreamBase {
             for await (const atom of this) {
                 // Determine whether non-ok values should be filtered out
                 if (options?.atoms !== true && !isOk(atom)) {
+                    continue;
+                }
+
+                // Skip undefined values (they cannot be serialised into JSON)
+                if (atom.value === undefined) {
                     continue;
                 }
 


### PR DESCRIPTION
## Completed
- Adds check that skips atoms w/ undefined values when serialising windpipe streams to JSON
- Adds tests to windpipe for JSON serialisation

## Cards
Was causing this issue
https://clearlrs.atlassian.net/issues/CL-15437?jql=summary%20%21~%20ALARM%20AND%20summary%20%21~%20%22Job%20Failed%22%20AND%20status%20%21%3D%20Closed%20AND%20created%20%3E%3D%202025-01-19%20AND%20created%20%3C%3D%20%222025-01-25%2023%3A59%22%20AND%20resolution%20%3D%20Unresolved